### PR TITLE
Add py2json new data-type customisation like Decimal

### DIFF
--- a/aiohttp_jsonrpc/handler.py
+++ b/aiohttp_jsonrpc/handler.py
@@ -15,6 +15,7 @@ class JSONRPCView(View):
 
     DUMPS = json.dumps
     LOADS = json.loads
+    PY2JSON = py2json
 
     @asyncio.coroutine
     def post(self, *args, **kwargs):
@@ -133,4 +134,4 @@ class JSONRPCView(View):
 
     @classmethod
     def _build_json(cls, data):
-        return cls.DUMPS(py2json(data), ensure_ascii=False)
+        return cls.DUMPS(cls.PY2JSON(data), ensure_ascii=False)


### PR DESCRIPTION
Change  JSONRPCFlatResource for add custom fields types to py2json
in my code

from decimal impor Decimal
import simplejson
from aiohttp_jsonrpc import handler, common

@common.py2json.register(Decimal)
def _(value):
    return value

class JSONRPCFlatResource(handler.JSONRPCView):

    DUMPS = simplejson.dumps
    LOADS = simplejson.loads
    PY2JSON = common.py2json