### PR TITLE
__JSONRPC_EXCEPTIONS__ field for exception mapping

### DIFF
--- a/aiohttp_jsonrpc/handler.py
+++ b/aiohttp_jsonrpc/handler.py
@@ -17,6 +17,8 @@ class JSONRPCView(View):
     DUMPS = json.dumps
     LOADS = json.loads
 
+    __JSONRPC_EXCEPTIONS__ = {}
+
     async def post(self):
         self._check_request()
 
@@ -132,12 +134,17 @@ class JSONRPCView(View):
 
         return data
 
-    @staticmethod
-    def _format_error(exception: Exception, request_id):
+    def _format_error(self, exception: Exception, request_id):
         data = {
-            "jsonrpc": "2.0",
-            "error": exception,
+            "jsonrpc": "2.0"
         }
+        if exception.__class__ in self.__JSONRPC_EXCEPTIONS__:
+            data["error"] = {
+                "code": self.__JSONRPC_EXCEPTIONS__[exception.__class__],
+                "message": str(exception)
+            }
+        else:
+            data["error"] = exception
 
         if request_id is not None:
             data["id"] = request_id

--- a/tests/test_custom_client_exceptions.py
+++ b/tests/test_custom_client_exceptions.py
@@ -1,0 +1,75 @@
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer, TestClient
+
+from aiohttp_jsonrpc.client import ServerProxy
+from aiohttp_jsonrpc.handler import JSONRPCView
+
+
+class CustomServerException(Exception):
+    code = 5001
+
+
+class CustomClientException(Exception):
+    code = 5001
+
+
+class JSONRPCTestService(JSONRPCView):
+    __JSONRPC_EXCEPTIONS__ = {
+        CustomServerException: CustomServerException.code
+    }
+
+    def rpc_echo_exception(self, message):
+        raise CustomServerException(message)
+
+
+class CustomServerProxy(ServerProxy):
+    __JSONRPC_EXCEPTIONS__ = {
+        CustomClientException.code: CustomClientException
+    }
+
+
+def create_app():
+    app = web.Application()
+    app.router.add_route("*", "/", JSONRPCTestService)
+    return app
+
+
+@pytest.fixture
+def custom_jsonrpc_test_client(add_cleanup):
+    test_client = None
+    rpc_client = None
+
+    async def _create_from_app_factory(app_factory, *args, **kwargs):
+        nonlocal test_client, rpc_client
+
+        app = app_factory(*args, **kwargs)
+        test_client = TestClient(TestServer(app))
+
+        await test_client.start_server()
+
+        rpc_client = CustomServerProxy("", client=test_client)
+
+        add_cleanup(rpc_client.close)
+        add_cleanup(test_client.close)
+
+        return rpc_client
+
+    return _create_from_app_factory
+
+
+@pytest.fixture
+async def custom_client(loop, custom_jsonrpc_test_client):
+    return await custom_jsonrpc_test_client(create_app)
+
+
+async def test_custom_handler_exception(custom_client):
+    """
+    This test shows that server raises CustomServerException
+    and CustomServerProxy re-raises exception CustomClientException,
+    which is defined in it's __JSONRPC_EXCEPTIONS__ dict.
+    """
+    with pytest.raises(CustomClientException) as exc_info:
+        await custom_client.echo_exception('My message')
+
+    assert exc_info.value.args[0] == 'My message'

--- a/tests/test_custom_server_exceptions.py
+++ b/tests/test_custom_server_exceptions.py
@@ -1,0 +1,41 @@
+import pytest
+from aiohttp import web
+
+from aiohttp_jsonrpc.handler import JSONRPCView
+
+
+class CustomServerException(Exception):
+    code = 5001
+
+
+class JSONRPCTestService(JSONRPCView):
+    __JSONRPC_EXCEPTIONS__ = {
+        CustomServerException: CustomServerException.code
+    }
+
+    def rpc_echo_exception(self, message):
+        raise CustomServerException(message)
+
+
+def create_app():
+    app = web.Application()
+    app.router.add_route("*", "/", JSONRPCTestService)
+    return app
+
+
+@pytest.fixture
+async def client(loop, jsonrpc_test_client):
+    return await jsonrpc_test_client(create_app)
+
+
+async def test_custom_server_exception(client):
+    """
+    This test shows that server raises CustomServerException,
+    which is defined in it's __JSONRPC_EXCEPTIONS__ dict,
+    and client gets an exception with code of CustomServerException.
+    """
+    with pytest.raises(Exception) as exc_info:
+        await client.echo_exception('My message')
+
+    assert exc_info.value.args[0] == 'My message'
+    assert getattr(exc_info.value, 'code') == 5001


### PR DESCRIPTION
I suggest a mechanism of not using exception mapping in the global scope.

You can define exception mapping in a view:
`
class JSONRPCTestService(JSONRPCView):
    __JSONRPC_EXCEPTIONS__ = {
        CustomServerException: CustomServerException.code
    }
`
The view will search an exception in this field, and if there is no such exception then fall back to the global exception mapping


On the client-side, you can also define exception mapping for ServerProxy like this
`
class CustomServerProxy(ServerProxy):
    __JSONRPC_EXCEPTIONS__ = {
        CustomClientException.code: CustomClientException
    }
`
The ServerProxy will search error code in this field and raise the appropriate exception. If there's no such code in __JSONRPC_EXCEPTIONS__, then it falls back global exception mapping.

Thus, you can have several views, which raises the same kind of exception, but return them with different codes.
And also you can have several ServcerProxy objects for different kinds of services, which error code sets intersect.
